### PR TITLE
chore: change diagnose project ID from `textarea` to `input`

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -125,6 +125,13 @@ body:
 
   - type: textarea
     attributes:
+      label: Project Identifier
+      description: |
+        You can send your project configurations by running `amplify diagnose --send-report` and share the Project Identifier. 
+        Learn more at https://docs.amplify.aws/cli/reference/diagnose/
+
+  - type: textarea
+    attributes:
       label: Additional information
       description: |
         If you have any additional information, workarounds, etc. for us, use the field below.

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -123,7 +123,7 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: input
     attributes:
       label: Project Identifier
       description: |


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-adminui/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

per [this comment on my previous PR](https://github.com/aws-amplify/amplify-adminui/pull/659/files#r967250643), adjusting `textarea` to `input` for the `amplify diagnose` project ID field

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
