### PR TITLE
Add angular and vue online-only api snippets

### DIFF
--- a/markdown/tests/web/angular_step5_data_code_api.md
+++ b/markdown/tests/web/angular_step5_data_code_api.md
@@ -1,0 +1,95 @@
+:::NEW_COMMAND:::
+:::CREATE:::
+
+```js
+import { API } from "aws-amplify";
+import { create:::MODEL::: } from './graphql/mutations';
+```
+
+```js
+:::NO_COPY:::
+...
+```
+
+```js
+const new:::MODEL::: = await API.graphql({
+    query: create:::MODEL:::,
+    variables: {
+        input: {:::FIELDS:::}
+    }
+});
+```
+
+:::NEW_COMMAND:::
+:::UPDATE:::
+
+```js
+import { API } from "aws-amplify";
+import { update:::MODEL::: } from './graphql/mutations';
+```
+
+```js
+:::NO_COPY:::
+...
+```
+
+```js
+const updated:::MODEL::: = await API.graphql({
+    query: update:::MODEL:::,
+    variables: {
+        input: {:::FIELDS:::}
+    }
+});
+```
+
+:::NEW_COMMAND:::
+:::DELETE:::
+
+```js
+import { API } from "aws-amplify";
+import { delete:::MODEL::: } from './graphql/mutations';
+```
+
+```js
+:::NO_COPY:::
+...
+```
+
+```js
+const deleted:::MODEL::: = await API.graphql({
+    query: delete:::MODEL:::,
+    variables: {
+        input: {
+            id: "YOUR_RECORD_ID"
+        }
+    }
+});
+```
+
+:::NEW_COMMAND:::
+:::QUERY:::
+
+```js
+import { API } from "aws-amplify";
+import { list:::MODEL:::s, get:::MODEL::: } from "./graphql/queries";
+```
+
+```js
+:::NO_COPY:::
+...
+```
+
+```js
+// List all items
+const all:::MODEL:::s = await API.graphql({
+    query: list:::MODEL:::s
+});
+console.log(all:::MODEL:::);
+```
+```js
+// Get a specific item
+const one:::MODEL::: = await API.graphql({
+    query: get:::MODEL:::,
+    variables: { id: 'YOUR_RECORD_ID' }
+});
+```

--- a/markdown/tests/web/vue_step5_data_code_api.md
+++ b/markdown/tests/web/vue_step5_data_code_api.md
@@ -1,0 +1,95 @@
+:::NEW_COMMAND:::
+:::CREATE:::
+
+```js
+import { API } from "aws-amplify";
+import { create:::MODEL::: } from './graphql/mutations';
+```
+
+```js
+:::NO_COPY:::
+...
+```
+
+```js
+const new:::MODEL::: = await API.graphql({
+    query: create:::MODEL:::,
+    variables: {
+        input: {:::FIELDS:::}
+    }
+});
+```
+
+:::NEW_COMMAND:::
+:::UPDATE:::
+
+```js
+import { API } from "aws-amplify";
+import { update:::MODEL::: } from './graphql/mutations';
+```
+
+```js
+:::NO_COPY:::
+...
+```
+
+```js
+const updated:::MODEL::: = await API.graphql({
+    query: update:::MODEL:::,
+    variables: {
+        input: {:::FIELDS:::}
+    }
+});
+```
+
+:::NEW_COMMAND:::
+:::DELETE:::
+
+```js
+import { API } from "aws-amplify";
+import { delete:::MODEL::: } from './graphql/mutations';
+```
+
+```js
+:::NO_COPY:::
+...
+```
+
+```js
+const deleted:::MODEL::: = await API.graphql({
+    query: delete:::MODEL:::,
+    variables: {
+        input: {
+            id: "YOUR_RECORD_ID"
+        }
+    }
+});
+```
+
+:::NEW_COMMAND:::
+:::QUERY:::
+
+```js
+import { API } from "aws-amplify";
+import { list:::MODEL:::s, get:::MODEL::: } from "./graphql/queries";
+```
+
+```js
+:::NO_COPY:::
+...
+```
+
+```js
+// List all items
+const all:::MODEL:::s = await API.graphql({
+    query: list:::MODEL:::s
+});
+console.log(all:::MODEL:::);
+```
+```js
+// Get a specific item
+const one:::MODEL::: = await API.graphql({
+    query: get:::MODEL:::,
+    variables: { id: 'YOUR_RECORD_ID' }
+});
+```


### PR DESCRIPTION
#### Description of changes
Added API code snippets for online only APIs Angular and and Vue.

They are equivalent to the [react one](https://github.com/aws-amplify/amplify-adminui/blob/main/markdown/tests/web/react_step5_data_code_api.md), so copying the same version into each.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
