### PR TITLE
chore: add pending-triage to new bug, add checks and wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -1,4 +1,4 @@
-name: Bug report
+name: Bug Report
 description: Create a report to help us improve the Amplify Studio
 labels: ["pending-triage"]
 

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Create a report to help us improve the Amplify Admin UI
+description: Create a report to help us improve the Amplify Studio
 labels: ["pending-triage"]
 
 body:
@@ -11,9 +11,9 @@ body:
       value: |
         Thank you for taking the time to fill out this bug report! Try to include as much information as you can.
 
-        > For **Amplify Console** issues, go [here](https://github.com/aws-amplify/amplify-console/issues/new/choose).
-        > For **Amplify CLI** issues, go [here](https://github.com/aws-amplify/amplify-cli/issues/new/choose).
-        > For **Amplify UI** issues, go [here](https://github.com/aws-amplify/amplify-ui/issues/new/choose).
+        - For **Amplify CLI** issues, visit [amplify-cli](https://github.com/aws-amplify/amplify-cli/issues/new/choose)
+        - For **Amplify Hosting** issues, visit [amplify-hosting](https://github.com/aws-amplify/amplify-hosting/issues/new/choose)
+        - For **Amplify UI** issues, visit [amplify-ui](https://github.com/aws-amplify/amplify-ui/issues/new/choose).
 
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -1,5 +1,7 @@
 name: Bug report
 description: Create a report to help us improve the Amplify Admin UI
+labels: ["pending-triage"]
+
 body:
   - type: markdown
     attributes:
@@ -7,7 +9,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Note**: If your issue is regarding the AWS Amplify CLI, please log it in the [Amplify CLI GitHub Issue Tracker](https://github.com/aws-amplify/amplify-cli/issues).
+        Thank you for taking the time to fill out this bug report! Try to include as much information as you can.
+
+        > For **Amplify Console** issues, go [here](https://github.com/aws-amplify/amplify-console/issues/new/choose).
+        > For **Amplify CLI** issues, go [here](https://github.com/aws-amplify/amplify-cli/issues/new/choose).
+        > For **Amplify UI** issues, go [here](https://github.com/aws-amplify/amplify-ui/issues/new/choose).
 
   - type: checkboxes
     attributes:
@@ -19,6 +25,8 @@ body:
         - label: I have read the guide for [submitting bug reports](https://github.com/aws-amplify/amplify-adminui/blob/main/CONTRIBUTING.md#bug-reports).
           required: true
         - label: I have done my best to include a minimal, self-contained set of instructions for consistently reproducing the issue.
+          required: true
+        - label: I have removed any sensitive information from my code snippets and submission.
           required: true
 
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yaml
@@ -9,11 +9,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to fill out this bug report! Try to include as much information as you can.
+        > **Note**: If your question is regarding the AWS Amplify Hosting, Amplify UI, or Amplify CLI, refer to
+        > - For **Amplify Hosting** issues, visit [amplify-hosting](https://github.com/aws-amplify/amplify-hosting/issues/new/choose)
+        > - For **Amplify UI** issues, visit [amplify-ui](https://github.com/aws-amplify/amplify-ui/issues/new/choose)
+        > - For **Amplify CLI** issues, visit [amplify-cli](https://github.com/aws-amplify/amplify-cli/issues/new/choose)
 
-        - For **Amplify CLI** issues, visit [amplify-cli](https://github.com/aws-amplify/amplify-cli/issues/new/choose)
-        - For **Amplify Hosting** issues, visit [amplify-hosting](https://github.com/aws-amplify/amplify-hosting/issues/new/choose)
-        - For **Amplify UI** issues, visit [amplify-ui](https://github.com/aws-amplify/amplify-ui/issues/new/choose).
 
   - type: checkboxes
     attributes:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-adminui/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds pending-triage to all new bugs. This will help automate the triage workflow and reduce overhead of manually assigning this label by converging on using pending-triage as the triage entrypoint rather than both "no label" and "pending-triage". Allows the team to better understand the issues that need triaging.

#### Issue #, if available

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
